### PR TITLE
Fix destroy

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,0 +1,5 @@
+Before you create a issue, check it:
+
+ 1. Try [dev](https://github.com/RubaXa/Sortable/tree/dev/)-branch, perhaps the problem has been solved;
+ 2. [Use the search](https://github.com/RubaXa/Sortable/search?q=problem), maybe already have an answer;
+ 3. If not found, create example on [jsbin.com (draft)](http://jsbin.com/zunibaxada/1/edit?html,js,output) and describe the problem.

--- a/README.md
+++ b/README.md
@@ -283,9 +283,9 @@ Sortable.create(list, {
 
 #### `forceFallback` option
 If set to `true`, the Fallback for non HTML5 Browser will be used, even if we are using an HTML5 Browser.
-This gives us the possiblity to test the behaviour for older Browsers even in newer Browser, or make the Drag 'n Drop feel more consistent between Desktop , Mobile and old Browsers.
+This gives us the possibility to test the behaviour for older Browsers even in newer Browser, or make the Drag 'n Drop feel more consistent between Desktop , Mobile and old Browsers.
 
-On top of that, the Fallback always generates a copy of that DOM Element and appends the class `fallbackClass` definied in the options. This behaviour controls the look of this 'dragged' Element.
+On top of that, the Fallback always generates a copy of that DOM Element and appends the class `fallbackClass` defined in the options. This behaviour controls the look of this 'dragged' Element.
 
 Demo: http://jsbin.com/pucurizace/edit?html,css,js,output
 

--- a/README.md
+++ b/README.md
@@ -443,6 +443,64 @@ React.render(<div>
 </div>, document.body);
 ```
 
+### Support React ES2015 / TypeScript syntax
+As mixins are not supported in ES2015 / TypeScript syntax here is example of ES2015 ref based implementation.
+Using refs is the preferred (by facebook) "escape hatch" to underlaying DOM nodes: [React: The ref Callback Attribute](https://facebook.github.io/react/docs/more-about-refs.html#the-ref-callback-attribute)
+
+```js
+import * as React from "react";
+import Sortable from 'sortablejs';
+
+export class SortableExampleEsnext extends React.Component {
+
+  sortableContainersDecorator = (componentBackingInstance) => {
+    // check if backing instance not null
+    if (componentBackingInstance) {
+      let options = {
+        handle: ".group-title" // Restricts sort start click/touch to the specified element
+      };
+      Sortable.create(componentBackingInstance, options);
+    }
+  };
+
+  sortableGroupDecorator = (componentBackingInstance) => {
+    // check if backing instance not null
+    if (componentBackingInstance) {
+      let options = {
+        draggable: "div" // Specifies which items inside the element should be sortable
+        group: "shared"
+      };
+      Sortable.create(componentBackingInstance, options);
+    }
+  };
+
+  render() {
+    return (
+      <div className="container" ref={this.sortableContainersDecorator}>
+        <div className="group">
+          <h2 className="group-title">Group 1</h2>
+          <div className="group-list" ref={this.sortableGroupDecorator}>
+            <div>Swap them around</div>
+            <div>Swap us around</div>
+            <div>Swap things around</div>
+            <div>Swap everything around</div>
+          </div>
+        </div>
+        <div className="group">
+          <h2 className="group-title">Group 2</h2>
+          <div className="group-list" ref={this.sortableGroupDecorator}>
+            <div>Swap them around</div>
+            <div>Swap us around</div>
+            <div>Swap things around</div>
+            <div>Swap everything around</div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+}
+```
+
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -689,7 +689,7 @@ Please, [read this](CONTRIBUTING.md).
 
 
 ## MIT LICENSE
-Copyright 2013-2015 Lebedev Konstantin <ibnRubaXa@gmail.com>
+Copyright 2013-2016 Lebedev Konstantin <ibnRubaXa@gmail.com>
 http://rubaxa.github.io/Sortable/
 
 Permission is hereby granted, free of charge, to any person obtaining

--- a/README.md
+++ b/README.md
@@ -482,7 +482,7 @@ Other attributes are:
   <template is="dom-repeat" items={{names}}>
     <div>{{item}}</div>
   </template>
-<sortable-js>
+</sortable-js>
 ```
 
 ### Method

--- a/Sortable.html
+++ b/Sortable.html
@@ -61,8 +61,9 @@
     },
 
     detached: function() {
-      this.sortable.destroy()
+      this.destroy()
     },
+
 
     initialize: function() {
 
@@ -120,6 +121,12 @@
         }
       }))
 
+    },
+
+    destroy: function() {
+      if(this.sortable) {
+        this.sortable.destroy()
+      }
     },
 
     groupChanged             : function(value) { this.sortable && this.sortable.option("group", value) },

--- a/Sortable.html
+++ b/Sortable.html
@@ -55,6 +55,17 @@
       //       <span>hello</span>
       //       <template is="dom-if">
       //     <tempalte is="dom-repeat">
+
+      this.initialize();
+
+    },
+
+    detached: function() {
+      this.sortable.destroy()
+    },
+
+    initialize: function() {
+
       var templates = this.querySelectorAll("template[is='dom-repeat']")
       var template = templates[templates.length-1]
 
@@ -108,10 +119,7 @@
           this.fire("move", e)
         }
       }))
-    },
 
-    detached: function() {
-      this.sortable.destroy()
     },
 
     groupChanged             : function(value) { this.sortable && this.sortable.option("group", value) },

--- a/Sortable.js
+++ b/Sortable.js
@@ -23,7 +23,7 @@
 	}
 })(function () {
 	"use strict";
-	
+
 	if (typeof window == "undefined" || typeof window.document == "undefined") {
 		return function() {
 			throw new Error( "Sortable.js requires a window with a document" );
@@ -813,9 +813,8 @@
 						this.save();
 					}
 				}
-
+				this._nulling();
 			}
-			this._nulling();
 		},
 
 		_nulling: function() {


### PR DESCRIPTION
Don't null object links (rootEl, dragEl, etc) on Destroy. There are scenarios where this causes `Sortable.js:1096 Uncaught TypeError: Cannot read property 'dispatchEvent' of null`. For example, this happens on Angular when you drag items containing sub-Sortables between lists. When you drop an item, it naturally executes onDrop. At the same time it destroys its sub-list (a child Sortable), which also calls onDrop. The latter onDrop resets the links, and that breaks the workflow of the initial onDrop. 
